### PR TITLE
SSCS-10166-build gradle updated for new version of sscs common

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ dependencies {
 
   implementation 'com.github.hmcts.ccd-case-migration-starter:domain:3.0.0'
   implementation 'com.github.hmcts.ccd-case-migration-starter:processor:3.0.0'
-  implementation 'com.github.hmcts:sscs-common:4.6.38'
+  implementation 'com.github.hmcts:sscs-common:4.6.45-RC-SSCS-10166'
 
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
   compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.8'

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ dependencies {
 
   implementation 'com.github.hmcts.ccd-case-migration-starter:domain:3.0.0'
   implementation 'com.github.hmcts.ccd-case-migration-starter:processor:3.0.0'
-  implementation 'com.github.hmcts:sscs-common:4.6.45-RC-SSCS-10166'
+  implementation 'com.github.hmcts:sscs-common:4.6.45'
 
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
   compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.8'


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10166

### Change description ###
poi and opencvs versions are updated in sscs-common as the security vulnerabilities they have are preventing feature developments


**Does this PR introduce a breaking change?** (check one with "x")

```
[X ] Yes
[ ] No
```
