### PR TITLE
SSCS-10348 base location fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ dependencies {
 
   implementation 'com.github.hmcts.ccd-case-migration-starter:domain:3.0.0'
   implementation 'uk.gov.hmcts.reform.ccd-case-migration:processor:DEV-SNAPSHOT'
-  implementation 'com.github.hmcts:sscs-common:4.9.3'
+  implementation 'com.github.hmcts:sscs-common:4.9.4-RC-SSCS-10517-2'
   implementation 'com.github.hmcts:idam-java-client:2.0.1'
 
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.8'

--- a/src/main/java/uk/gov/hmcts/reform/sscs/migration/LocationDataMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/migration/LocationDataMigration.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.sscs.migration;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.CaseManagementLocation;
@@ -11,15 +11,11 @@ import uk.gov.hmcts.reform.sscs.model.CourtVenue;
 import uk.gov.hmcts.reform.sscs.service.RefDataService;
 
 @Service
+@RequiredArgsConstructor
 @ConditionalOnProperty(value = "migration.location_data.enabled", havingValue = "true")
 public class LocationDataMigration implements DataMigrationStep {
 
     private final RefDataService refDataService;
-
-    @Autowired
-    public LocationDataMigration(RefDataService refDataService) {
-        this.refDataService = refDataService;
-    }
 
     @Override
     public void apply(SscsCaseData sscsCaseData) {
@@ -27,10 +23,11 @@ public class LocationDataMigration implements DataMigrationStep {
     }
 
     private void addCaseManagementLocation(SscsCaseData sscsCaseData) {
-        String venue = sscsCaseData.getProcessingVenue();
+        String processingVenueName = sscsCaseData.getProcessingVenue();
 
-        if (!isEmpty(venue)) {
-            CourtVenue courtVenue = refDataService.getVenueRefData(venue);
+        if (isNotBlank(processingVenueName)) {
+            CourtVenue courtVenue = refDataService.getVenueRefData(processingVenueName);
+
             if (courtVenue != null) {
                 sscsCaseData.setCaseManagementLocation(CaseManagementLocation.builder()
                     .baseLocation(courtVenue.getEpimsId())

--- a/src/main/java/uk/gov/hmcts/reform/sscs/migration/LocationDataMigration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/migration/LocationDataMigration.java
@@ -1,21 +1,19 @@
 package uk.gov.hmcts.reform.sscs.migration;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.sscs.ccd.domain.CaseManagementLocation;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.model.CourtVenue;
-import uk.gov.hmcts.reform.sscs.service.RefDataService;
+import uk.gov.hmcts.reform.sscs.migration.helper.PostcodeResolver;
+import uk.gov.hmcts.reform.sscs.migration.service.CaseManagementLocationService;
 
 @Service
 @RequiredArgsConstructor
 @ConditionalOnProperty(value = "migration.location_data.enabled", havingValue = "true")
 public class LocationDataMigration implements DataMigrationStep {
 
-    private final RefDataService refDataService;
+    private final PostcodeResolver postcodeResolver;
+    private final CaseManagementLocationService caseManagementLocationService;
 
     @Override
     public void apply(SscsCaseData sscsCaseData) {
@@ -24,15 +22,9 @@ public class LocationDataMigration implements DataMigrationStep {
 
     private void addCaseManagementLocation(SscsCaseData sscsCaseData) {
         String processingVenueName = sscsCaseData.getProcessingVenue();
+        String postcode = postcodeResolver.resolvePostcode(sscsCaseData.getAppeal());
 
-        if (isNotBlank(processingVenueName)) {
-            CourtVenue courtVenue = refDataService.getVenueRefData(processingVenueName);
-
-            if (courtVenue != null) {
-                sscsCaseData.setCaseManagementLocation(CaseManagementLocation.builder()
-                    .baseLocation(courtVenue.getEpimsId())
-                    .region(courtVenue.getRegionId()).build());
-            }
-        }
+        caseManagementLocationService.retrieveCaseManagementLocation(processingVenueName, postcode)
+            .ifPresent(sscsCaseData::setCaseManagementLocation);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/migration/helper/PostcodeResolver.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/migration/helper/PostcodeResolver.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.sscs.migration.helper;
+
+import java.util.Optional;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appointee;
+
+@Component
+public class PostcodeResolver {
+
+    public String resolvePostcode(@NonNull Appeal appeal) {
+        return Optional.ofNullable(appeal.getAppellant())
+            .map(Appellant::getAppointee)
+            .map(Appointee::getAddress)
+            .map(Address::getPostcode)
+            .orElse(Optional.ofNullable(appeal.getAppellant())
+                .map(Appellant::getAddress)
+                .map(Address::getPostcode)
+                .orElse(StringUtils.EMPTY));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/CaseManagementLocationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/CaseManagementLocationService.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.sscs.migration.service;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.CaseManagementLocation;
+import uk.gov.hmcts.reform.sscs.model.CourtVenue;
+import uk.gov.hmcts.reform.sscs.service.RefDataService;
+
+@Service
+@RequiredArgsConstructor
+public class CaseManagementLocationService {
+
+    private final RefDataService refDataService;
+    private final RpcVenueService rpcVenueService;
+
+    public Optional<CaseManagementLocation> retrieveCaseManagementLocation(String processingVenue, String postcode) {
+        if (isNotBlank(processingVenue)
+            && isNotBlank(postcode)) {
+
+            CourtVenue courtVenue = refDataService.getVenueRefData(processingVenue);
+            String rpcEpimsId = rpcVenueService.retrieveRpcEpimsIdForPostcode(postcode);
+
+            if (nonNull(courtVenue)
+                && isNotBlank(courtVenue.getRegionId())
+                && isNotBlank(rpcEpimsId)) {
+                return Optional.of(CaseManagementLocation.builder()
+                    .baseLocation(rpcEpimsId)
+                    .region(courtVenue.getRegionId())
+                    .build());
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/RpcVenueService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/RpcVenueService.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.sscs.migration.service;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.RegionalProcessingCenter;
+import uk.gov.hmcts.reform.sscs.service.RegionalProcessingCenterService;
+import uk.gov.hmcts.reform.sscs.service.VenueService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RpcVenueService {
+
+    private final RegionalProcessingCenterService regionalProcessingCenterService;
+    private final VenueService venueService;
+
+    public String retrieveRpcEpimsIdForPostcode(@NonNull String postcode) {
+        RegionalProcessingCenter rpc = regionalProcessingCenterService.getByPostcode(postcode);
+
+        return venueService.getEpimsIdForActiveVenueByPostcode(rpc.getPostcode())
+            .orElseGet(() -> {
+                log.error("Unable to retrieve venue epims id for RPC - {}", rpc.getName());
+                return StringUtils.EMPTY;
+            });
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/migration/CaseAccessManagementDataMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/migration/CaseAccessManagementDataMigrationTest.java
@@ -15,9 +15,9 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Benefit;
 import uk.gov.hmcts.reform.sscs.ccd.domain.BenefitType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.CaseAccessManagementFields;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.domain.WorkAllocationFields;
 
 @ExtendWith(MockitoExtension.class)
 class CaseAccessManagementDataMigrationTest {
@@ -47,36 +47,36 @@ class CaseAccessManagementDataMigrationTest {
     @Test
     void testCategoriesForEmptyBenefitType(@Mock SscsCaseData caseDataMock) {
         when(caseDataMock.getAppeal()).thenReturn(Appeal.builder().build());
-        when(caseDataMock.getWorkAllocationFields()).thenReturn(WorkAllocationFields.builder().build());
+        when(caseDataMock.getCaseAccessManagementFields()).thenReturn(CaseAccessManagementFields.builder().build());
         caseAccessManagementDataMigration.apply(caseDataMock);
 
-        assertNull(caseDataMock.getWorkAllocationFields().getCaseAccessCategory());
-        assertNull(caseDataMock.getWorkAllocationFields().getCaseManagementCategory());
+        assertNull(caseDataMock.getCaseAccessManagementFields().getCaseAccessCategory());
+        assertNull(caseDataMock.getCaseAccessManagementFields().getCaseManagementCategory());
     }
 
     @Test
     void testCategoriesForGivenBenefitType() {
         caseAccessManagementDataMigration.apply(caseData);
 
-        assertNotNull(caseData.getWorkAllocationFields());
-        assertEquals("personalIndependencePayment", caseData.getWorkAllocationFields().getCaseAccessCategory());
-        assertEquals(Benefit.PIP.getShortName(), caseData.getWorkAllocationFields().getCaseManagementCategory().getListItems().get(0).getCode());
-        assertEquals(Benefit.PIP.getDescription(), caseData.getWorkAllocationFields().getCaseManagementCategory().getListItems().get(0).getLabel());
+        assertNotNull(caseData.getCaseAccessManagementFields());
+        assertEquals("personalIndependencePayment", caseData.getCaseAccessManagementFields().getCaseAccessCategory());
+        assertEquals(Benefit.PIP.getShortName(), caseData.getCaseAccessManagementFields().getCaseManagementCategory().getListItems().get(0).getCode());
+        assertEquals(Benefit.PIP.getDescription(), caseData.getCaseAccessManagementFields().getCaseManagementCategory().getListItems().get(0).getLabel());
     }
 
     @Test
     void testCaseNameAppellant() {
         caseAccessManagementDataMigration.apply(caseData);
 
-        assertEquals("First Last", caseData.getWorkAllocationFields().getCaseNameHmctsInternal());
-        assertEquals("First Last", caseData.getWorkAllocationFields().getCaseNameHmctsRestricted());
-        assertEquals("First Last", caseData.getWorkAllocationFields().getCaseNamePublic());
+        assertEquals("First Last", caseData.getCaseAccessManagementFields().getCaseNameHmctsInternal());
+        assertEquals("First Last", caseData.getCaseAccessManagementFields().getCaseNameHmctsRestricted());
+        assertEquals("First Last", caseData.getCaseAccessManagementFields().getCaseNamePublic());
     }
 
     @Test
     void testOgdType() {
         caseAccessManagementDataMigration.apply(caseData);
 
-        assertEquals("DWP", caseData.getWorkAllocationFields().getOgdType());
+        assertEquals("DWP", caseData.getCaseAccessManagementFields().getOgdType());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/migration/LocationDataMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/migration/LocationDataMigrationTest.java
@@ -1,44 +1,65 @@
 package uk.gov.hmcts.reform.sscs.migration;
 
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
-import org.junit.Ignore;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.model.CourtVenue;
 import uk.gov.hmcts.reform.sscs.service.RefDataService;
 
-
-public class LocationDataMigrationTest {
+class LocationDataMigrationTest {
 
     @Mock
     private RefDataService refDataService;
 
+    @InjectMocks
     private LocationDataMigration locationDataMigration;
 
     @BeforeEach
     public void setup() {
         openMocks(this);
-        locationDataMigration = new LocationDataMigration(refDataService);
-        when(refDataService.getVenueRefData(anyString())).thenReturn(CourtVenue.builder().epimsId("epimms_id").regionId("region_id").build());
     }
 
-    @Ignore
     @Test
-    public void testRefData() {
-        SscsCaseData caseData = SscsCaseData.builder().build();
-        locationDataMigration.apply(caseData);
-        Assertions.assertNull(caseData.getCaseManagementLocation());
+    void shouldSetCaseManagementLocationFieldsAsExpected_givenValidCaseData() {
+        SscsCaseData caseData = SscsCaseData.builder()
+            .processingVenue("Bradford")
+            .build();
 
-        caseData.setProcessingVenue("Bradford");
+        when(refDataService.getVenueRefData("Bradford"))
+            .thenReturn(CourtVenue.builder().epimsId("epimms_id").regionId("region_id").build());
+
         locationDataMigration.apply(caseData);
-        Assertions.assertNotNull(caseData.getCaseManagementLocation());
-        Assertions.assertEquals("epimms_id", caseData.getCaseManagementLocation().getBaseLocation());
-        Assertions.assertEquals("region_id", caseData.getCaseManagementLocation().getRegion());
+
+        assertNotNull(caseData.getCaseManagementLocation());
+        assertEquals("epimms_id", caseData.getCaseManagementLocation().getBaseLocation());
+        assertEquals("region_id", caseData.getCaseManagementLocation().getRegion());
+    }
+
+    @Test
+    void shouldNotSetCaseManagementLocation_givenProcessingVenueIsBlank() {
+        SscsCaseData caseData = SscsCaseData.builder()
+            .processingVenue("")
+            .build();
+
+        locationDataMigration.apply(caseData);
+
+        assertNull(caseData.getCaseManagementLocation());
+    }
+
+    @Test
+    void shouldNotSetCaseManagementLocation_givenProcessingVenueIsNull() {
+        SscsCaseData caseData = SscsCaseData.builder().build();
+
+        locationDataMigration.apply(caseData);
+
+        assertNull(caseData.getCaseManagementLocation());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/migration/LocationDataMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/migration/LocationDataMigrationTest.java
@@ -1,29 +1,37 @@
 package uk.gov.hmcts.reform.sscs.migration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
+import uk.gov.hmcts.reform.sscs.ccd.domain.CaseManagementLocation;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.model.CourtVenue;
-import uk.gov.hmcts.reform.sscs.service.RefDataService;
+import uk.gov.hmcts.reform.sscs.migration.helper.PostcodeResolver;
+import uk.gov.hmcts.reform.sscs.migration.service.CaseManagementLocationService;
 
+@RunWith(MockitoJUnitRunner.class)
 class LocationDataMigrationTest {
 
     @Mock
-    private RefDataService refDataService;
+    private PostcodeResolver postcodeResolver;
+
+    @Mock
+    private CaseManagementLocationService caseManagementLocationService;
 
     @InjectMocks
     private LocationDataMigration locationDataMigration;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         openMocks(this);
     }
 
@@ -31,35 +39,17 @@ class LocationDataMigrationTest {
     void shouldSetCaseManagementLocationFieldsAsExpected_givenValidCaseData() {
         SscsCaseData caseData = SscsCaseData.builder()
             .processingVenue("Bradford")
+            .appeal(Appeal.builder().build())
             .build();
 
-        when(refDataService.getVenueRefData("Bradford"))
-            .thenReturn(CourtVenue.builder().epimsId("epimms_id").regionId("region_id").build());
+        when(postcodeResolver.resolvePostcode(Appeal.builder().build())).thenReturn("postcode");
+        when(caseManagementLocationService.retrieveCaseManagementLocation("Bradford", "postcode"))
+            .thenReturn(Optional.of(CaseManagementLocation.builder().baseLocation("rpcEpimsId").region("regionId").build()));
 
         locationDataMigration.apply(caseData);
 
         assertNotNull(caseData.getCaseManagementLocation());
-        assertEquals("epimms_id", caseData.getCaseManagementLocation().getBaseLocation());
-        assertEquals("region_id", caseData.getCaseManagementLocation().getRegion());
-    }
-
-    @Test
-    void shouldNotSetCaseManagementLocation_givenProcessingVenueIsBlank() {
-        SscsCaseData caseData = SscsCaseData.builder()
-            .processingVenue("")
-            .build();
-
-        locationDataMigration.apply(caseData);
-
-        assertNull(caseData.getCaseManagementLocation());
-    }
-
-    @Test
-    void shouldNotSetCaseManagementLocation_givenProcessingVenueIsNull() {
-        SscsCaseData caseData = SscsCaseData.builder().build();
-
-        locationDataMigration.apply(caseData);
-
-        assertNull(caseData.getCaseManagementLocation());
+        assertThat(caseData.getCaseManagementLocation().getBaseLocation()).isEqualTo("rpcEpimsId");
+        assertThat(caseData.getCaseManagementLocation().getRegion()).isEqualTo("regionId");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/migration/helper/PostcodeResolverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/migration/helper/PostcodeResolverTest.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.sscs.migration.helper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appointee;
+
+class PostcodeResolverTest {
+
+    private final PostcodeResolver unitUnderTest = new PostcodeResolver();
+
+    @Test
+    void shouldReturnBlankPostcode_givenAppointeeAndAppellantPostcodeDoNotExist() {
+        Appellant testAppellant = Appellant.builder()
+            .address(Address.builder().build())
+            .appointee(Appointee.builder()
+                .address(Address.builder().build())
+                .build())
+            .build();
+
+        String actualPostcode = unitUnderTest.resolvePostcode(Appeal.builder()
+            .appellant(testAppellant)
+            .build());
+
+        assertThat(actualPostcode).isEmpty();
+    }
+
+    @Test
+    void shouldReturnBlankPostcode_givenAppointeeAndAppellantAddressDoNotExist() {
+        Appellant testAppellant = Appellant.builder().build();
+
+        String actualPostcode = unitUnderTest.resolvePostcode(Appeal.builder()
+            .appellant(testAppellant)
+            .build());
+
+        assertThat(actualPostcode).isEmpty();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/CaseManagementLocationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/CaseManagementLocationServiceTest.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.reform.sscs.migration.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.sscs.ccd.domain.CaseManagementLocation;
+import uk.gov.hmcts.reform.sscs.model.CourtVenue;
+import uk.gov.hmcts.reform.sscs.service.RefDataService;
+
+@RunWith(MockitoJUnitRunner.class)
+class CaseManagementLocationServiceTest {
+
+    @Mock
+    private RefDataService refDataService;
+
+    @Mock
+    private RpcVenueService rpcVenueService;
+
+    @InjectMocks
+    private CaseManagementLocationService caseManagementLocationService;
+
+    @BeforeEach
+    void setup() {
+        openMocks(this);
+    }
+
+    @Test
+    void shouldNotRetrieveCaseManagementLocation_givenBlankProcessingVenue() {
+        Optional<CaseManagementLocation> caseManagementLocation =
+            caseManagementLocationService.retrieveCaseManagementLocation("", "postcode");
+
+        assertThat(caseManagementLocation).isEmpty();
+    }
+
+    @Test
+    void shouldNotRetrieveCaseManagementLocation_givenBlankPostcode() {
+        Optional<CaseManagementLocation> caseManagementLocation =
+            caseManagementLocationService.retrieveCaseManagementLocation("venue", "");
+
+        assertThat(caseManagementLocation).isEmpty();
+    }
+
+    @Test
+    void shouldNotRetrieveCaseManagementLocation_givenInvalidProcessingVenue() {
+        when(refDataService.getVenueRefData("Bradford")).thenReturn(null);
+
+        Optional<CaseManagementLocation> caseManagementLocation =
+            caseManagementLocationService.retrieveCaseManagementLocation("Bradford", "BD1 1RX");
+
+        assertThat(caseManagementLocation).isEmpty();
+    }
+
+    @Test
+    void shouldNotRetrieveCaseManagementLocation_givenInvalidCourtVenue() {
+        when(refDataService.getVenueRefData("Bradford")).thenReturn(CourtVenue.builder().build());
+
+        Optional<CaseManagementLocation> caseManagementLocation =
+            caseManagementLocationService.retrieveCaseManagementLocation("Bradford", "BD1 1RX");
+
+        assertThat(caseManagementLocation).isEmpty();
+    }
+
+    @Test
+    void shouldNotRetrieveCaseManagementLocation_givenInvalidPostcode() {
+        when(refDataService.getVenueRefData("Bradford")).thenReturn(CourtVenue.builder().regionId("regionId").build());
+        when(rpcVenueService.retrieveRpcEpimsIdForPostcode("BD1 1RX")).thenReturn(null);
+
+        Optional<CaseManagementLocation> caseManagementLocation =
+            caseManagementLocationService.retrieveCaseManagementLocation("Bradford", "BD1 1RX");
+
+        assertThat(caseManagementLocation).isEmpty();
+    }
+
+    @Test
+    void shouldRetrieveCaseManagementLocation_givenValidProcessingVenue_andPostcode() {
+        when(refDataService.getVenueRefData("Bradford")).thenReturn(CourtVenue.builder().regionId("regionId").build());
+        when(rpcVenueService.retrieveRpcEpimsIdForPostcode("BD1 1RX")).thenReturn("rpcEpimsId");
+
+        Optional<CaseManagementLocation> caseManagementLocation =
+            caseManagementLocationService.retrieveCaseManagementLocation("Bradford", "BD1 1RX");
+
+        assertThat(caseManagementLocation).isPresent();
+        CaseManagementLocation result = caseManagementLocation.get();
+        assertThat(result.getBaseLocation()).isEqualTo("rpcEpimsId");
+        assertThat(result.getRegion()).isEqualTo("regionId");
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/RpcVenueServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/RpcVenueServiceTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.sscs.migration.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.sscs.ccd.domain.RegionalProcessingCenter;
+import uk.gov.hmcts.reform.sscs.service.RegionalProcessingCenterService;
+import uk.gov.hmcts.reform.sscs.service.VenueService;
+
+@RunWith(MockitoJUnitRunner.class)
+class RpcVenueServiceTest {
+
+    @Mock
+    private RegionalProcessingCenterService regionalProcessingCenterService;
+
+    @Mock
+    private VenueService venueService;
+
+    @InjectMocks
+    private RpcVenueService rpcVenueService;
+
+    @BeforeEach
+    void setup() {
+        openMocks(this);
+    }
+
+    @Test
+    void shouldGetEpimsId_givenValidAppellant() {
+        when(regionalProcessingCenterService.getByPostcode("postcode")).thenReturn(
+            RegionalProcessingCenter.builder().postcode("rpcPostcode").build());
+        when(venueService.getEpimsIdForActiveVenueByPostcode("rpcPostcode")).thenReturn(Optional.of("rpcEpimsId"));
+
+        String rpcEpimsId = rpcVenueService.retrieveRpcEpimsIdForPostcode("postcode");
+
+        assertThat(rpcEpimsId).isEqualTo("rpcEpimsId");
+    }
+
+    @Test
+    void shouldGetEmptyString_givenEpimsIdIsEmpty() {
+        when(regionalProcessingCenterService.getByPostcode("postcode")).thenReturn(RegionalProcessingCenter.builder().postcode("rpcPostcode").build());
+        when(venueService.getEpimsIdForActiveVenueByPostcode("rpcPostcode")).thenReturn(Optional.empty());
+
+        String rpcEpimsId = rpcVenueService.retrieveRpcEpimsIdForPostcode("postcode");
+
+        assertThat(rpcEpimsId).isEmpty();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/SscsDataMigrationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/SscsDataMigrationServiceTest.java
@@ -38,7 +38,7 @@ class SscsDataMigrationServiceTest {
     private SscsDataMigrationService sscsDataMigrationService;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         openMocks(this);
         sscsDataMigrationService = new SscsDataMigrationService(
             sscsCcdConvertService,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-10348

### Change description ###

- updated caseData fields from common
- tidied up LocationDataMigration and updated tests
- implemented new base location logic and updated tests

Logic here is pretty much identical to https://github.com/hmcts/sscs-bulk-scan/pull/1260 without the postcode validation, as we can assume if the data is in CCD it has already been validated previously.

Build fails as the code is using a local snapshot of https://github.com/hmcts/ccd-case-migration-starter/tree/sscs-9911-improved - the artifact/jar will be built locally when needed.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[ x ] No
```
