### PR TITLE
SSCS-10586 reworked court venue lookup

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/CaseManagementLocationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/CaseManagementLocationService.java
@@ -8,20 +8,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.CaseManagementLocation;
 import uk.gov.hmcts.reform.sscs.model.CourtVenue;
-import uk.gov.hmcts.reform.sscs.service.RefDataService;
 
 @Service
 @RequiredArgsConstructor
 public class CaseManagementLocationService {
 
-    private final RefDataService refDataService;
+    private final CourtVenueService courtVenueService;
     private final RpcVenueService rpcVenueService;
 
     public Optional<CaseManagementLocation> retrieveCaseManagementLocation(String processingVenue, String postcode) {
         if (isNotBlank(processingVenue)
             && isNotBlank(postcode)) {
 
-            CourtVenue courtVenue = refDataService.getVenueRefData(processingVenue);
+            CourtVenue courtVenue = courtVenueService.lookupCourtVenueByName(processingVenue);
             String rpcEpimsId = rpcVenueService.retrieveRpcEpimsIdForPostcode(postcode);
 
             if (nonNull(courtVenue)

--- a/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/CourtVenueService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/CourtVenueService.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.sscs.migration.service;
+
+import com.google.common.collect.Maps;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.model.CourtVenue;
+
+@Service
+@RequiredArgsConstructor
+public class CourtVenueService {
+
+    private final LocationRefDataService locationRefDataService;
+    private final Map<String, CourtVenue> courtVenuesByVenueName = Maps.newHashMap();
+
+    @PostConstruct
+    protected void init() {
+        locationRefDataService.retrieveCourtVenues()
+            .forEach(courtVenue -> courtVenuesByVenueName.put(
+                courtVenue.getVenueName(),
+                courtVenue));
+    }
+
+    public CourtVenue lookupCourtVenueByName(String venueName) {
+        return courtVenuesByVenueName.get(venueName);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/LocationRefDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/LocationRefDataService.java
@@ -5,12 +5,14 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.client.RefDataApi;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.model.CourtVenue;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LocationRefDataService {
@@ -26,6 +28,7 @@ public class LocationRefDataService {
         if (idamTokens == null
             || (isBlank(idamTokens.getIdamOauth2Token())
                 && isBlank(idamTokens.getServiceAuthorization()))) {
+            log.error("Unable to retrieve IdamTokens");
             return Collections.emptyList();
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/LocationRefDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/migration/service/LocationRefDataService.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.sscs.migration.service;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.client.RefDataApi;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+import uk.gov.hmcts.reform.sscs.model.CourtVenue;
+
+@Service
+@RequiredArgsConstructor
+public class LocationRefDataService {
+
+    private static final String SSCS_COURT_TYPE_ID = "31";
+
+    private final IdamService idamService;
+    private final RefDataApi refDataApi;
+
+    public List<CourtVenue> retrieveCourtVenues() {
+        IdamTokens idamTokens = idamService.getIdamTokens();
+
+        if (idamTokens == null
+            || (isBlank(idamTokens.getIdamOauth2Token())
+                && isBlank(idamTokens.getServiceAuthorization()))) {
+            return Collections.emptyList();
+        }
+
+        return refDataApi.courtVenueByName(
+            idamTokens.getIdamOauth2Token(),
+            idamTokens.getServiceAuthorization(),
+            SSCS_COURT_TYPE_ID);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/CaseManagementLocationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/CaseManagementLocationServiceTest.java
@@ -13,13 +13,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.sscs.ccd.domain.CaseManagementLocation;
 import uk.gov.hmcts.reform.sscs.model.CourtVenue;
-import uk.gov.hmcts.reform.sscs.service.RefDataService;
 
 @RunWith(MockitoJUnitRunner.class)
 class CaseManagementLocationServiceTest {
 
     @Mock
-    private RefDataService refDataService;
+    private CourtVenueService courtVenueService;
 
     @Mock
     private RpcVenueService rpcVenueService;
@@ -50,7 +49,7 @@ class CaseManagementLocationServiceTest {
 
     @Test
     void shouldNotRetrieveCaseManagementLocation_givenInvalidProcessingVenue() {
-        when(refDataService.getVenueRefData("Bradford")).thenReturn(null);
+        when(courtVenueService.lookupCourtVenueByName("Bradford")).thenReturn(null);
 
         Optional<CaseManagementLocation> caseManagementLocation =
             caseManagementLocationService.retrieveCaseManagementLocation("Bradford", "BD1 1RX");
@@ -60,7 +59,7 @@ class CaseManagementLocationServiceTest {
 
     @Test
     void shouldNotRetrieveCaseManagementLocation_givenInvalidCourtVenue() {
-        when(refDataService.getVenueRefData("Bradford")).thenReturn(CourtVenue.builder().build());
+        when(courtVenueService.lookupCourtVenueByName("Bradford")).thenReturn(CourtVenue.builder().build());
 
         Optional<CaseManagementLocation> caseManagementLocation =
             caseManagementLocationService.retrieveCaseManagementLocation("Bradford", "BD1 1RX");
@@ -70,7 +69,7 @@ class CaseManagementLocationServiceTest {
 
     @Test
     void shouldNotRetrieveCaseManagementLocation_givenInvalidPostcode() {
-        when(refDataService.getVenueRefData("Bradford")).thenReturn(CourtVenue.builder().regionId("regionId").build());
+        when(courtVenueService.lookupCourtVenueByName("Bradford")).thenReturn(CourtVenue.builder().regionId("regionId").build());
         when(rpcVenueService.retrieveRpcEpimsIdForPostcode("BD1 1RX")).thenReturn(null);
 
         Optional<CaseManagementLocation> caseManagementLocation =
@@ -81,7 +80,7 @@ class CaseManagementLocationServiceTest {
 
     @Test
     void shouldRetrieveCaseManagementLocation_givenValidProcessingVenue_andPostcode() {
-        when(refDataService.getVenueRefData("Bradford")).thenReturn(CourtVenue.builder().regionId("regionId").build());
+        when(courtVenueService.lookupCourtVenueByName("Bradford")).thenReturn(CourtVenue.builder().regionId("regionId").build());
         when(rpcVenueService.retrieveRpcEpimsIdForPostcode("BD1 1RX")).thenReturn("rpcEpimsId");
 
         Optional<CaseManagementLocation> caseManagementLocation =

--- a/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/CourtVenueServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/CourtVenueServiceTest.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.sscs.migration.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.sscs.model.CourtVenue;
+
+@RunWith(MockitoJUnitRunner.class)
+class CourtVenueServiceTest {
+
+    @Mock
+    private LocationRefDataService locationRefDataService;
+
+    @InjectMocks
+    private CourtVenueService courtVenueService;
+
+    @BeforeEach
+    void setup() {
+        openMocks(this);
+        when(locationRefDataService.retrieveCourtVenues()).thenReturn(List.of(CourtVenue.builder()
+                .venueName("Bradford")
+                .regionId("bradford-regionId")
+            .build()));
+        courtVenueService.init();
+    }
+
+    @Test
+    void shouldReturnCourtVenue_givenVenueIsPresent() {
+        CourtVenue courtVenue = courtVenueService.lookupCourtVenueByName("Bradford");
+
+        assertThat(courtVenue).isNotNull();
+        assertThat(courtVenue.getRegionId()).isEqualTo("bradford-regionId");
+    }
+
+    @Test
+    void shouldReturnNull_givenVenueIsMissing() {
+        CourtVenue courtVenue = courtVenueService.lookupCourtVenueByName("Liverpool");
+
+        assertThat(courtVenue).isNull();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/LocationRefDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/migration/service/LocationRefDataServiceTest.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.reform.sscs.migration.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.sscs.client.RefDataApi;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+import uk.gov.hmcts.reform.sscs.model.CourtVenue;
+
+@RunWith(MockitoJUnitRunner.class)
+class LocationRefDataServiceTest {
+
+    private static final String SSCS_COURT_TYPE_ID = "31";
+
+    @Mock
+    private IdamService idamService;
+
+    @Mock
+    private RefDataApi refDataApi;
+
+    @InjectMocks
+    private LocationRefDataService locationRefDataService;
+
+    @BeforeEach
+    void setup() {
+        openMocks(this);
+    }
+
+    @Test
+    void shouldReturnEmptyList_givenIdamTokensIsNull() {
+        List<CourtVenue> courtVenues = locationRefDataService.retrieveCourtVenues();
+
+        verifyNoInteractions(refDataApi);
+        assertThat(courtVenues).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyList_givenIdamTokensIsEmpty() {
+        when(idamService.getIdamTokens()).thenReturn(IdamTokens.builder()
+            .idamOauth2Token(StringUtils.EMPTY)
+            .serviceAuthorization(StringUtils.EMPTY)
+            .build());
+
+        List<CourtVenue> courtVenues = locationRefDataService.retrieveCourtVenues();
+
+        verifyNoInteractions(refDataApi);
+        assertThat(courtVenues).isEmpty();
+    }
+
+    @Test
+    void shouldCallRefDataApiAsExpected_givenValidIdamTokensIsPresent() {
+        when(idamService.getIdamTokens()).thenReturn(IdamTokens.builder()
+            .idamOauth2Token("idamOauth2Token")
+            .serviceAuthorization("serviceAuthorization")
+            .build());
+
+        locationRefDataService.retrieveCourtVenues();
+
+        verify(refDataApi, times(1)).courtVenueByName(
+            "idamOauth2Token",
+            "serviceAuthorization",
+            SSCS_COURT_TYPE_ID);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-10586

### Change description ###

This change means only one call will be made to reference data during a migration tool run.

- refactored reference data service logic and added/updated tests

**Does this PR introduce a breaking change?**

```
[ ] Yes
[ x ] No
```
